### PR TITLE
Integration with JaCoCo and SonarCloud

### DIFF
--- a/.github/workflows/code-quality-check.yml
+++ b/.github/workflows/code-quality-check.yml
@@ -1,0 +1,49 @@
+name: Code quality check
+
+on:
+  push:
+    branches:
+      - '**'
+  pull_request:
+    branches:
+      - master
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Set up JDK 11
+        uses: actions/setup-java@v2
+        with:
+          java-version: '11'
+          distribution: 'adopt'
+
+      - name: checkout current repo
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0  # Shallow clones should be disabled for a better relevancy of sonarqube analysis
+
+      - name: Build with Maven
+        run: mvn clean -fae jacoco:prepare-agent test jacoco:report
+
+        # Runs a set of commands using the runners shell
+
+      - name: Cache SonarCloud packages
+        uses: actions/cache@v1
+        with:
+          path: ~/.sonar/cache
+          key: ${{ runner.os }}-sonar
+          restore-keys: ${{ runner.os }}-sonar
+      - name: Cache Maven packages
+        uses: actions/cache@v1
+        with:
+          path: ~/.m2
+          key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
+          restore-keys: ${{ runner.os }}-m2
+      - name: Build and analyze
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}  # Needed to get PR information, if any
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+        run: mvn -B verify org.sonarsource.scanner.maven:sonar-maven-plugin:sonar

--- a/pom.xml
+++ b/pom.xml
@@ -18,6 +18,13 @@
 		<maven.min-version>3.0.3</maven.min-version>
 
 		<janssen.version>1.0.0-SNAPSHOT</janssen.version>
+
+		<jacoco.version>0.8.7</jacoco.version>
+
+		<sonar.projectKey>JanssenProject_jans-core</sonar.projectKey>
+		<sonar.moduleKey>${project.groupId}:${project.artifactId}</sonar.moduleKey>
+		<sonar.organization>janssenproject</sonar.organization>
+		<sonar.host.url>https://sonarcloud.io</sonar.host.url>
 	</properties>
 
 	<scm>
@@ -165,6 +172,11 @@
 					<configuration>
 						<failOnError>false</failOnError>
 					</configuration>
+				</plugin>
+				<plugin>
+					<groupId>org.jacoco</groupId>
+					<artifactId>jacoco-maven-plugin</artifactId>
+					<version>${jacoco.version}</version>
 				</plugin>
 			</plugins>
 		</pluginManagement>


### PR DESCRIPTION
This PR integrates jans-core repo with SonarCloud and adds JaCoCo as code coverage tool for Java code.

It also adds a new workflow Code quality check to the repo. This workflow will perform static code analysis, run tests, report code coverage to SonarCloud.

After the first successful execution of the workflow, one can find the code quality data [here](https://sonarcloud.io/summary/new_code?id=JanssenProject_jans-core).